### PR TITLE
Refactor user role management and response structure

### DIFF
--- a/app/domain/schema/authSchema.py
+++ b/app/domain/schema/authSchema.py
@@ -72,3 +72,6 @@ class TokenResponse(BaseModel):
 class tokenLoginData(BaseModel):
     id: UUID
     role: str
+
+class UpdateRoleRequest(BaseModel):
+    role: str

--- a/app/router/endpoints/userRouter.py
+++ b/app/router/endpoints/userRouter.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException, Request
-from app.domain.schema.authSchema import signUp,login,editUser
+from app.domain.schema.authSchema import signUp,login,editUser, UpdateRoleRequest
 from fastapi import Depends, Header
 from app.service.userService import UserService, get_user_service
 from app.utils.middleware.dependancies import is_admin, is_logged_in
@@ -19,28 +19,33 @@ async def get_all_users(user_service: UserService = Depends(get_user_service)):
 
 #get user by id
 @userRouter.get("/{user_id}")
-async def get_user_by_id(user_id: int, user_service: UserService = Depends(get_user_service)):
+async def get_user_by_id(user_id: str, user_service: UserService = Depends(get_user_service)):
     return user_service.get_user_by_id(user_id)
 
 #deactivate user
 @userRouter.put("/deactivate/{user_id}")
-async def deactivate_user(user_id: int, user_service: UserService = Depends(get_user_service)):
+async def deactivate_user(user_id: str, user_service: UserService = Depends(get_user_service)):
     return user_service.deactivate_user(user_id)
 
 #activate user
 @userRouter.put("/activate/{user_id}")
-async def activate_user(user_id: int, user_service: UserService = Depends(get_user_service)):
+async def activate_user(user_id: str, user_service: UserService = Depends(get_user_service)):
     return user_service.activate_user(user_id)
 
 #delete user
 @userRouter.delete("/{user_id}")
-async def delete_user(user_id: int, user_service: UserService = Depends(get_user_service)):
+async def delete_user(user_id: str, user_service: UserService = Depends(get_user_service)):
     return user_service.delete_user(user_id)
 
-#update role
+
+
 @userRouter.put("/role/{user_id}")
-async def update_role(user_id: int, role: str, user_service: UserService = Depends(get_user_service)):
-    return user_service.update_role(user_id, role)
+async def update_role(
+    user_id: str, 
+    role_data: UpdateRoleRequest, 
+    user_service: UserService = Depends(get_user_service)
+):
+    return user_service.update_role(user_id, role_data.role)
 
 #user profile router
 rootRouter = APIRouter()

--- a/app/service/userService.py
+++ b/app/service/userService.py
@@ -24,7 +24,7 @@ class UserService:
         
         users_response = [UserResponse.model_validate(user) for user in users]
         #return the response
-        response = {"detail": "Users retrieved successfully", "users": users_response}
+        response = {"detail": "Users retrieved successfully", "data": users_response}
         return response
 
     #get user by id
@@ -46,7 +46,7 @@ class UserService:
         #     is_active=user.is_active
         # )
         #return the response
-        response = {"detail": "User retrieved successfully", "user": user_response}
+        response = {"detail": "User retrieved successfully", "data": user_response}
         return response
     
     #deactivate user
@@ -68,7 +68,7 @@ class UserService:
         #     is_active=user.is_active
         # )
         #return the response
-        response = {"detail": "User deactivated successfully", "user": user_response}
+        response = {"detail": "User deactivated successfully", "data": user_response}
         return response
         
     #activate user
@@ -90,7 +90,7 @@ class UserService:
         #     is_active=user.is_active
         # )
         #return the response
-        response = {"detail": "User activated successfully", "user": user_response}
+        response = {"detail": "User activated successfully", "data": user_response}
         return response
     
     #delete user
@@ -106,7 +106,7 @@ class UserService:
         return response
     
     #update role
-    def update_role(self, user_id: int, role: str):
+    def update_role(self, user_id: str, role: str):
         user = self.user_repo.update_role(user_id, role)
         #check if user exists
         if not user:
@@ -124,7 +124,7 @@ class UserService:
         #     is_active=user.is_active
         # )
         #return the response
-        response = {"detail": "User role updated successfully", "user": user_response}
+        response = {"detail": "User role updated successfully", "data": user_response}
         return response
     
     #get user by token
@@ -146,7 +146,7 @@ class UserService:
         #     is_active=user.is_active
         # )
         #return the response
-        response = {"detail": "User retrieved successfully", "user": user_response}
+        response = {"detail": "User retrieved successfully", "data": user_response}
         return response
     
     #edit user by token
@@ -175,7 +175,7 @@ class UserService:
         #     is_active=user.is_active
         # )
         #return the response
-        response = {"detail": "User updated successfully", "user": user_response}
+        response = {"detail": "User updated successfully", "data": user_response}
         return response
 
 


### PR DESCRIPTION
This pull request includes changes to the user role update functionality and response formatting in the `userService` and `userRouter` modules. The most important changes include the addition of a new `UpdateRoleRequest` class, modifications to user ID type handling, and updates to response data keys.

### User role update functionality:

* [`app/domain/schema/authSchema.py`](diffhunk://#diff-08af1ded6788cb20e5729a8a41d6b62bb04cc75e2fb6da1a4feeefb1708d54d8R75-R77): Added a new `UpdateRoleRequest` class to handle role updates.
* [`app/router/endpoints/userRouter.py`](diffhunk://#diff-820ad9ed3c68fdc86bb56ce6c13db31836b4edb05186bda49380e4c27b384fc9L2-R2): Updated the import statement to include `UpdateRoleRequest` and modified the `update_role` endpoint to use `UpdateRoleRequest` for role data. [[1]](diffhunk://#diff-820ad9ed3c68fdc86bb56ce6c13db31836b4edb05186bda49380e4c27b384fc9L2-R2) [[2]](diffhunk://#diff-820ad9ed3c68fdc86bb56ce6c13db31836b4edb05186bda49380e4c27b384fc9L22-R48)

### User ID type handling:

* [`app/router/endpoints/userRouter.py`](diffhunk://#diff-820ad9ed3c68fdc86bb56ce6c13db31836b4edb05186bda49380e4c27b384fc9L22-R48): Changed user ID type from `int` to `str` in several endpoint functions to ensure consistency.
* [`app/service/userService.py`](diffhunk://#diff-0ef0dbd2f0ff86333c1de89f3ee73e235f2fa504aed5072064c0a38cda7ad75bL109-R109): Updated user ID type from `int` to `str` in the `update_role` method.

### Response formatting updates:

* [`app/service/userService.py`](diffhunk://#diff-0ef0dbd2f0ff86333c1de89f3ee73e235f2fa504aed5072064c0a38cda7ad75bL27-R27): Changed the key from `user` to `data` in the response dictionaries for various user-related methods to standardize response formatting. [[1]](diffhunk://#diff-0ef0dbd2f0ff86333c1de89f3ee73e235f2fa504aed5072064c0a38cda7ad75bL27-R27) [[2]](diffhunk://#diff-0ef0dbd2f0ff86333c1de89f3ee73e235f2fa504aed5072064c0a38cda7ad75bL49-R49) [[3]](diffhunk://#diff-0ef0dbd2f0ff86333c1de89f3ee73e235f2fa504aed5072064c0a38cda7ad75bL71-R71) [[4]](diffhunk://#diff-0ef0dbd2f0ff86333c1de89f3ee73e235f2fa504aed5072064c0a38cda7ad75bL93-R93) [[5]](diffhunk://#diff-0ef0dbd2f0ff86333c1de89f3ee73e235f2fa504aed5072064c0a38cda7ad75bL127-R127) [[6]](diffhunk://#diff-0ef0dbd2f0ff86333c1de89f3ee73e235f2fa504aed5072064c0a38cda7ad75bL149-R149) [[7]](diffhunk://#diff-0ef0dbd2f0ff86333c1de89f3ee73e235f2fa504aed5072064c0a38cda7ad75bL178-R178)